### PR TITLE
don't wait for connect event in server

### DIFF
--- a/lib/tcplock.js
+++ b/lib/tcplock.js
@@ -42,9 +42,9 @@ exports.TCPLock.prototype = {
 		var _this = this;
 		
 		this.server = net.createServer(function (connection) {
-			connection.on('connect', function () {
-				_this._enqueueConnection(connection);
-			});
+
+			_this._enqueueConnection(connection);
+
 			
 			connection.on('data', function (data) {
 				try {


### PR DESCRIPTION
Since the server callback is already called on the "connect" even, it is not necessary to wait for the "connect" even from the client. In fact, this event will not even be emitted again in Node 0.10.

This patch makes the module work with Node.js 0.10.
